### PR TITLE
Remove redundant ThirdPartyBucketRead roles

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence,
 # these owners will be requested for review when someone
 # opens a pull request.
-*       @dav3r @felddy @jsf9k @mcdonnnj @cisagov/team-ois
+*       @dav3r @felddy @hillaryj @jsf9k @mcdonnnj @cisagov/team-ois

--- a/terraform-test-user/main.tf
+++ b/terraform-test-user/main.tf
@@ -19,48 +19,19 @@ module "iam_user" {
   }
 }
 
-module "third_party_bucket_read_production" {
-  source = "github.com/cisagov/s3-read-role-tf-module"
-
-  providers = {
-    aws = aws.images-production-s3
-  }
-
-  account_ids   = [local.users_account_id]
-  entity_name   = module.iam_user.user.name
-  iam_usernames = [module.iam_user.user.name]
-  role_name     = "ThirdPartyBucketRead-${module.iam_user.user.name}"
-  s3_bucket     = data.terraform_remote_state.images_production.outputs.third_party_bucket.id
-  s3_objects    = ["Nessus-*-debian6_amd64.deb"]
-}
-
-# Attach ThirdPartyBucketRead policy to the Production EC2AMICreate role
+# Attach Production ThirdPartyBucketRead policy to
+# the Production EC2AMICreate role
 resource "aws_iam_role_policy_attachment" "thirdpartybucketread_production" {
   provider = aws.images-production-ami
 
-  policy_arn = module.third_party_bucket_read_production.policy.arn
+  policy_arn = data.terraform_remote_state.ansible_role_nessus.outputs.production_policy.arn
   role       = module.iam_user.ec2amicreate_role_production.name
 }
 
-module "third_party_bucket_read_staging" {
-  source = "github.com/cisagov/s3-read-role-tf-module"
-
-  providers = {
-    aws = aws.images-staging-s3
-  }
-
-  account_ids   = [local.users_account_id]
-  entity_name   = module.iam_user.user.name
-  iam_usernames = [module.iam_user.user.name]
-  role_name     = "ThirdPartyBucketRead-${module.iam_user.user.name}"
-  s3_bucket     = data.terraform_remote_state.images_staging.outputs.third_party_bucket.id
-  s3_objects    = ["Nessus-*-debian6_amd64.deb"]
-}
-
-# Attach ThirdPartyBucketRead policy to the Staging EC2AMICreate role
+# Attach Staging ThirdPartyBucketRead policy to the Staging EC2AMICreate role
 resource "aws_iam_role_policy_attachment" "thirdpartybucketread_staging" {
   provider = aws.images-staging-ami
 
-  policy_arn = module.third_party_bucket_read_staging.policy.arn
+  policy_arn = data.terraform_remote_state.ansible_role_nessus.outputs.staging_policy.arn
   role       = module.iam_user.ec2amicreate_role_staging.name
 }

--- a/terraform-test-user/remote_states.tf
+++ b/terraform-test-user/remote_states.tf
@@ -4,6 +4,19 @@
 # for this configuration.
 # ------------------------------------------------------------------------------
 
+data "terraform_remote_state" "ansible_role_nessus" {
+  backend = "s3"
+
+  config = {
+    encrypt        = true
+    bucket         = "cisa-cool-terraform-state"
+    dynamodb_table = "terraform-state-lock"
+    profile        = "cool-terraform-backend"
+    region         = "us-east-1"
+    key            = "ansible-role-nessus/terraform.tfstate"
+  }
+}
+
 data "terraform_remote_state" "images_parameterstore_production" {
   backend = "s3"
 


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR removes two ThirdPartyBucketRead roles (Production and Staging) created by this repo, and instead re-uses the ThirdPartyBucketRead policies that were created for [`ansible-role-nessus`](https://github.com/cisagov/ansible-role-nessus/blob/develop/terraform/outputs.tf#L1-L14).
<!--- Describe your changes in detail -->

## 💭 Motivation and Context
To paraphrase @jsf9k: "Fewer roles means fewer attack surfaces."

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
After I did a `terraform apply` with these changes, I confirmed that the `test-nessus-packer` user was still able to read the contents of both third party buckets (Production and Staging).

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
